### PR TITLE
Add codiceIPA to publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -53,6 +53,8 @@ it:
     cie: false
     pagopa: false
     spid: false
+  riuso:
+    codiceIPA: r_lomb
 legal:
   license: AGPL-3.0-only
   mainCopyrightOwner: Consiglio regionale della Lombardia


### PR DESCRIPTION
Buongiorno @danieledepetris,
questa PR:
* aggiunge la chiave `codiceIPA` all'interno della chiave `riuso` per facilitare l'indicizzazione del software nella categoria corretta (software a riuso).

Resto a disposizione.
Grazie